### PR TITLE
#17 add r5py

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ python-docx
 #pinned because of a dependency issue, this is otherwise not deliberately installer
 #rasterio==1.3.10
 #contextily
+r5py
 geopandas
 seaborn
 folium

--- a/requirements.txt
+++ b/requirements.txt
@@ -139,6 +139,8 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
+configargparse==1.7
+    # via r5py
 configurable-http-proxy==0.3.0
     # via -r requirements.in
 contourpy==1.3.1
@@ -190,11 +192,14 @@ executing==2.1.0
     # via stack-data
 fastjsonschema==2.20.0
     # via nbformat
+filelock==3.17.0
+    # via r5py
 fiona==1.10.1
     # via
     #   -r requirements.in
     #   centerline
     #   geopandas
+    #   r5py
 folium==0.18.0
     # via -r requirements.in
 fonttools==4.55.0
@@ -223,6 +228,7 @@ geopandas==0.14.4
     #   libpysal
     #   momepy
     #   osmnx
+    #   r5py
 geopy==2.4.1
     # via
     #   -r requirements.in
@@ -260,6 +266,8 @@ importlib-metadata==8.5.0
     # via
     #   jupyter-cache
     #   myst-nb
+importlib-resources==6.5.2
+    # via r5py
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
@@ -308,7 +316,11 @@ jinja2==3.1.4
     #   sphinx
     #   sqlfluff
 joblib==1.4.2
-    # via scikit-learn
+    # via
+    #   r5py
+    #   scikit-learn
+jpype1==1.5.2
+    # via r5py
 json5==0.9.28
     # via jupyterlab-server
 jsonpickle==4.0.0
@@ -521,6 +533,7 @@ numpy==1.26.4
     #   pandas
     #   patsy
     #   pyerfa
+    #   r5py
     #   scikit-learn
     #   scipy
     #   seaborn
@@ -551,6 +564,7 @@ packaging==24.2
     #   geopandas
     #   holoviews
     #   ipykernel
+    #   jpype1
     #   jupyter-server
     #   jupyterhub
     #   jupyterlab
@@ -581,6 +595,7 @@ pandas==2.2.3
     #   osmnx
     #   pandas-bokeh
     #   panel
+    #   r5py
     #   seaborn
     #   shap
     #   statsmodels
@@ -643,6 +658,7 @@ psutil==6.1.0
     # via
     #   -r requirements.in
     #   ipykernel
+    #   r5py
 psycopg==3.2.3
     # via -r requirements.in
 psycopg2==2.9.10
@@ -685,7 +701,9 @@ pygments==2.18.0
 pyparsing==3.2.0
     # via matplotlib
 pyproj==3.7.0
-    # via geopandas
+    # via
+    #   geopandas
+    #   r5py
 pyproject-hooks==1.2.0
     # via
     #   build
@@ -733,6 +751,8 @@ pyzmq==26.2.0
     #   jupyter-client
     #   jupyter-console
     #   jupyter-server
+r5py==0.1.2
+    # via -r requirements.in
 ratelim==0.1.6
     # via geocoder
 referencing==0.35.1
@@ -752,6 +772,7 @@ requests==2.32.3
     #   libpysal
     #   osmnx
     #   panel
+    #   r5py
     #   requests-oauthlib
     #   sphinx
 requests-oauthlib==2.0.0
@@ -802,6 +823,7 @@ shapely==2.0.6
     #   libpysal
     #   momepy
     #   osmnx
+    #   r5py
 six==1.16.0
     # via
     #   asttokens


### PR DESCRIPTION
Also installed `openjdk21` as a dependency for this package. 
R5 jar version: `r5-v7.1-r5py-all.jar`
A config file is placed in `/etc/r5py.yml` for the following configuration

```
r5-classpath: /data/jupyterhub/.venv/share/java/r5/r5-v7.1-r5py-all.jar
max-memory: 3G
```
Closes #17 
