### PR TITLE
#61 Check requirements.txt installs without error

### DIFF
--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -1,0 +1,21 @@
+name: Test DAGs
+
+on: pull_request
+
+jobs:
+  test_dags:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    #help to identify if dependabot PRs can be closed without conflict
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt

--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   test_dags:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Ubuntu 22.04 LTS (Jammy Jellyfish)
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION
A basic install requirements.txt action, copied from bdit-data-sources (minus dags test).

Let's see if this helps with the dependabot PRs before we try something new for changes to requirements.in?